### PR TITLE
[RESERVATION-SEAT-LOG] 예매 좌석 이벤트 수신 및 로그 저장 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,10 +69,10 @@ dependencies {
     // PostgreSQL
     implementation 'org.postgresql:postgresql'
 
-    implementation 'io.github.tickatch:common-lib:0.0.4'
+    implementation 'io.github.tickatch:common-lib:0.0.5'
 
     // Prometheus
-    implementation 'io.prometheus:simpleclient_pushgateway:0.16.0'
+    implementation 'io.prometheus:prometheus-metrics-exporter-pushgateway'
 
     // lombok
     compileOnly 'org.projectlombok:lombok'

--- a/init.sql
+++ b/init.sql
@@ -15,3 +15,18 @@ CREATE TABLE log_service.p_event_log
     service_name   VARCHAR(100) NOT NULL,
     created_at     TIMESTAMP    NOT NULL DEFAULT NOW()
 );
+
+CREATE TABLE log_service.p_reservation_seat_log
+(
+    id                  UUID PRIMARY KEY,
+
+    reservation_seat_id BIGINT       NOT NULL,
+    seat_number         VARCHAR(255) NOT NULL,
+
+    action_type         VARCHAR(20)  NOT NULL,
+
+    actor_type          VARCHAR(20)  NOT NULL,
+    actor_user_id       UUID         NULL,
+
+    occurred_at         TIMESTAMP    NOT NULL
+);

--- a/src/main/java/com/tickatch/logservice/global/config/rabbitmq/RabbitMQConfig.java
+++ b/src/main/java/com/tickatch/logservice/global/config/rabbitmq/RabbitMQConfig.java
@@ -1,0 +1,101 @@
+package com.tickatch.logservice.global.config.rabbitmq;
+
+import io.github.tickatch.common.util.JsonUtils;
+import org.springframework.amqp.core.Binding;
+import org.springframework.amqp.core.BindingBuilder;
+import org.springframework.amqp.core.ExchangeBuilder;
+import org.springframework.amqp.core.Queue;
+import org.springframework.amqp.core.QueueBuilder;
+import org.springframework.amqp.core.TopicExchange;
+import org.springframework.amqp.rabbit.config.SimpleRabbitListenerContainerFactory;
+import org.springframework.amqp.rabbit.connection.ConnectionFactory;
+import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
+import org.springframework.amqp.support.converter.MessageConverter;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class RabbitMQConfig {
+
+  /* =========================
+   * Exchange / Queue / Routing
+   * ========================= */
+  public static final String LOG_EXCHANGE = "tickatch.log";
+
+  public static final String QUEUE_RESERVATION_SEAT_LOG = "tickatch.reservation-seat.log.queue";
+
+  public static final String ROUTING_KEY_RESERVATION_SEAT_LOG = "reservation-seat.log";
+
+  /* =========================
+   * Exchange
+   * ========================= */
+  @Bean
+  public TopicExchange logExchange() {
+    return ExchangeBuilder.topicExchange(LOG_EXCHANGE).durable(true).build();
+  }
+
+  /* =========================
+   * Queue
+   * ========================= */
+  @Bean
+  public Queue reservationSeatLogQueue() {
+    return QueueBuilder.durable(QUEUE_RESERVATION_SEAT_LOG)
+        .withArgument("x-dead-letter-exchange", LOG_EXCHANGE + ".dlx")
+        .withArgument("x-dead-letter-routing-key", "dlq." + ROUTING_KEY_RESERVATION_SEAT_LOG)
+        .build();
+  }
+
+  /* =========================
+   * Binding
+   * ========================= */
+  @Bean
+  public Binding reservationSeatLogBinding(
+      Queue reservationSeatLogQueue, TopicExchange logExchange) {
+    return BindingBuilder.bind(reservationSeatLogQueue)
+        .to(logExchange)
+        .with(ROUTING_KEY_RESERVATION_SEAT_LOG);
+  }
+
+  /* =========================
+   * Dead Letter
+   * ========================= */
+  @Bean
+  public TopicExchange deadLetterExchange() {
+    return ExchangeBuilder.topicExchange(LOG_EXCHANGE + ".dlx").durable(true).build();
+  }
+
+  @Bean
+  public Queue reservationSeatLogDlq() {
+    return QueueBuilder.durable(QUEUE_RESERVATION_SEAT_LOG + ".dlq").build();
+  }
+
+  @Bean
+  public Binding reservationSeatLogDlqBinding(
+      Queue reservationSeatLogDlq, TopicExchange deadLetterExchange) {
+    return BindingBuilder.bind(reservationSeatLogDlq)
+        .to(deadLetterExchange)
+        .with("dlq." + ROUTING_KEY_RESERVATION_SEAT_LOG);
+  }
+
+  /* =========================
+   * Message Converter
+   * ========================= */
+  @Bean
+  public MessageConverter jsonMessageConverter() {
+    return new Jackson2JsonMessageConverter(JsonUtils.getObjectMapper());
+  }
+
+  /* =========================
+   * Listener Factory
+   * ========================= */
+  @Bean
+  public SimpleRabbitListenerContainerFactory rabbitListenerContainerFactory(
+      ConnectionFactory connectionFactory, MessageConverter jsonMessageConverter) {
+    SimpleRabbitListenerContainerFactory factory = new SimpleRabbitListenerContainerFactory();
+    factory.setConnectionFactory(connectionFactory);
+    factory.setMessageConverter(jsonMessageConverter);
+    factory.setDefaultRequeueRejected(false); // 실패 시 DLQ
+    factory.setPrefetchCount(10);
+    return factory;
+  }
+}

--- a/src/main/java/com/tickatch/logservice/reservationseatlog/domain/ReservationSeatLog.java
+++ b/src/main/java/com/tickatch/logservice/reservationseatlog/domain/ReservationSeatLog.java
@@ -1,0 +1,59 @@
+package com.tickatch.logservice.reservationseatlog.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "p_reservation_seat_log")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ReservationSeatLog {
+
+  @Id
+  @Column(name = "id", nullable = false)
+  private UUID reservationSeatLogId;
+
+  @Column(name = "reservation_seat_id", nullable = false)
+  private Long reservationSeatId;
+
+  @Column(name = "seat_number", nullable = false)
+  private String seatNumber;
+
+  @Column(name = "action_type", nullable = false, length = 20)
+  private String actionType;
+
+  @Column(name = "actor_type", nullable = false, length = 20)
+  private String actorType;
+
+  @Column(name = "actor_user_id")
+  private UUID actorUserId;
+
+  @Column(name = "occurred_at", nullable = false)
+  private LocalDateTime occurredAt;
+
+  public static ReservationSeatLog create(
+      UUID reservationSeatLogId,
+      Long reservationSeatId,
+      String seatNumber,
+      String actionType,
+      String actorType,
+      UUID actorUserId,
+      LocalDateTime occurredAt) {
+    ReservationSeatLog log = new ReservationSeatLog();
+    log.reservationSeatLogId = reservationSeatLogId;
+    log.reservationSeatId = reservationSeatId;
+    log.seatNumber = seatNumber;
+    log.actionType = actionType;
+    log.actorType = actorType;
+    log.actorUserId = actorUserId;
+    log.occurredAt = occurredAt;
+    return log;
+  }
+}

--- a/src/main/java/com/tickatch/logservice/reservationseatlog/domain/event/ReservationSeatActionEvent.java
+++ b/src/main/java/com/tickatch/logservice/reservationseatlog/domain/event/ReservationSeatActionEvent.java
@@ -1,0 +1,13 @@
+package com.tickatch.logservice.reservationseatlog.domain.event;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record ReservationSeatActionEvent(
+    UUID eventId, // 발행 서비스에서 생성하는 이벤트 ID
+    Long reservationSeatId,
+    String seatNumber,
+    String actionType, // 좌석선점 / 예약확정 / 예약취소 / 좌석삭제
+    String actorType,
+    UUID actorUserId,
+    LocalDateTime occurredAt) {}

--- a/src/main/java/com/tickatch/logservice/reservationseatlog/domain/repository/ReservationSeatLogRepository.java
+++ b/src/main/java/com/tickatch/logservice/reservationseatlog/domain/repository/ReservationSeatLogRepository.java
@@ -1,0 +1,7 @@
+package com.tickatch.logservice.reservationseatlog.domain.repository;
+
+import com.tickatch.logservice.reservationseatlog.domain.ReservationSeatLog;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReservationSeatLogRepository extends JpaRepository<ReservationSeatLog, UUID> {}

--- a/src/main/java/com/tickatch/logservice/reservationseatlog/infrastructure/messaging/ReservationSeatLogConsumer.java
+++ b/src/main/java/com/tickatch/logservice/reservationseatlog/infrastructure/messaging/ReservationSeatLogConsumer.java
@@ -1,0 +1,45 @@
+package com.tickatch.logservice.reservationseatlog.infrastructure.messaging;
+
+import com.tickatch.logservice.global.config.rabbitmq.RabbitMQConfig;
+import com.tickatch.logservice.reservationseatlog.domain.ReservationSeatLog;
+import com.tickatch.logservice.reservationseatlog.domain.event.ReservationSeatActionEvent;
+import com.tickatch.logservice.reservationseatlog.domain.repository.ReservationSeatLogRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ReservationSeatLogConsumer {
+
+  private final ReservationSeatLogRepository reservationSeatLogRepository;
+
+  @RabbitListener(
+      queues = RabbitMQConfig.QUEUE_RESERVATION_SEAT_LOG,
+      containerFactory = "rabbitListenerContainerFactory")
+  @Transactional
+  public void consume(ReservationSeatActionEvent event) {
+    try {
+      log.debug("Consuming reservation seat log: {}", event);
+
+      ReservationSeatLog log =
+          ReservationSeatLog.create(
+              event.eventId(),
+              event.reservationSeatId(),
+              event.seatNumber(),
+              event.actionType(),
+              event.actorType(),
+              event.actorUserId(),
+              event.occurredAt());
+
+      reservationSeatLogRepository.save(log);
+
+    } catch (Exception e) {
+      log.error("Failed to save reservation seat log: {}", event, e);
+      throw e; // DLQ로 전송되도록
+    }
+  }
+}


### PR DESCRIPTION
See also: #10
Closes #10 
## 🛠️ 작업 내용 (Details)
예매 좌석 서비스에서 발생한 행위(Event)를 RabbitMQ로 수신하여  
Log 서비스에 그대로 저장하는 구조를 추가했습니다.

Log 서비스는 비즈니스 로직 없이 이벤트를 기록하는 역할만 수행하므로,  
Service 계층 없이 Consumer에서 Repository를 직접 호출하도록 구성했습니다.

이벤트 ID는 예매 좌석 서비스에서 생성하여 전달하며,  
이를 로그 테이블의 PK로 사용해 중복 이벤트 수신 상황에서도  
로그가 중복 저장되지 않도록 멱등성을 보장합니다.

## 🔀 변경 유형 (Change Type)

어떤 종류의 변경사항인지 해당 항목에 [x]를 표기해주세요.
- [x] 새로운 기능 추가 (non-breaking change which adds functionality)
- [ ] 코드 수정 (non-breaking change which fixes functionality)
- [ ] 버그 수정 (non-breaking change which fixes an issue)
- [ ] 코드 스타일 업데이트 (formatting, renaming)
- [ ] 코드 리팩토링 (non-breaking change which improves code)
- [ ] 문서 수정 (documentation only)
- [ ] 기타 (설명: )
- [ ] 성능 개선 (performance improvement)
- [ ] 파괴적인 변경 (breaking change which might cause existing functionality to break)


## 🧪 테스트 방법 (Testing)